### PR TITLE
Fix JS syntax in reset settings handler

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -331,7 +331,7 @@ jQuery(document).ready(function($) {
         }
         
         var $button = $(this);
-        $button.prop('disabled', true);;ohtdsrk;o
+        $button.prop('disabled', true);
         
         
         $.ajax({


### PR DESCRIPTION
## Summary
- remove stray characters in the reset settings AJAX handler

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68517592cdcc8325bb91ddaae2ad74ab