### PR TITLE
Fix activation warnings and update slug logic

### DIFF
--- a/includes/github-updater.php
+++ b/includes/github-updater.php
@@ -42,10 +42,12 @@ function mec_check_for_updates($transient) {
         return $transient;
     }
 
+    $plugin_slug = $plugin_basename;
+
     $proxy_url = add_query_arg(array(
-        'plugin_slug' => 'secure-fluentform-uploads',
-        'version' => $current_version,
-        'key' => 'nJ8pHP2xBGeHR23GMuFUuwkzIeCfQ9GXhMGd2tP32xoW3b51BpQbbwzaDsBPstWO',
+        'plugin_slug' => $plugin_slug,
+        'version'    => $current_version,
+        'key'        => 'nJ8pHP2xBGeHR23GMuFUuwkzIeCfQ9GXhMGd2tP32xoW3b51BpQbbwzaDsBPstWO',
     ), 'https://update.makingtheimpact.com/');
 
     try {
@@ -92,10 +94,10 @@ function mec_check_for_updates($transient) {
         if (!empty($update_data['new_version']) && !empty($update_data['package'])) {
             if (version_compare($update_data['new_version'], $current_version, '>')) {
                 $update_object = (object) array(
-                    'slug' => 'secure-fluentform-uploads',
-                    'new_version' => $update_data['new_version'],
-                    'url' => $update_data['url'] ?? '',
-                    'package' => $update_data['package'],
+                    'slug'       => $plugin_slug,
+                    'new_version'=> $update_data['new_version'],
+                    'url'        => $update_data['url'] ?? '',
+                    'package'    => $update_data['package'],
                 );
 
                 set_transient('mec_update_check', $update_object, MEC_UPDATE_CACHE_TIME);

--- a/secure-fluentform-uploads.php
+++ b/secure-fluentform-uploads.php
@@ -277,8 +277,6 @@ function sffu_activate() {
         dbDelta($sql);
     }
 
-    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-    dbDelta($sql);
 
     // Set version
     update_option('sffu_version', SFFU_VERSION);


### PR DESCRIPTION
## Summary
- remove duplicate `dbDelta` call during activation
- use plugin directory name when contacting update server

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6851aa75918083259e7c846e991e5136