### PR TITLE
Improve file type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ The plugin can be configured through the WordPress admin panel:
 - Enable/disable automatic cleanup
 - View access logs
 
+## Testing
+
+To verify file type restrictions:
+
+1. In plugin settings, allow only a specific extension (for example `pdf`).
+2. Upload a file with that extension through a FluentForm field—upload should succeed.
+3. Attempt to upload a file with a disallowed extension (for example `exe`).
+   The submission should be blocked with a "File type not allowed" message.
+
 ## Support
 
 For support, please [open an issue](https://github.com/makingtheimpact/secure-fluentform-uploads/issues) on GitHub.

--- a/uninstall.php
+++ b/uninstall.php
@@ -36,7 +36,6 @@ delete_option('sffu_link_expiry_unit');
 delete_option('sffu_cleanup_enabled');
 delete_option('sffu_cleanup_interval');
 delete_option('sffu_cleanup_unit');
-delete_option('sffu_allowed_types');
 delete_option('sffu_allowed_roles');
 delete_option('sffu_file_cipher_key');
 delete_option('sffu_keep_records_on_uninstall');


### PR DESCRIPTION
## Summary
- validate uploads using `sffu_settings` allowed extensions
- stop using obsolete `sffu_allowed_types` option
- document manual testing instructions

## Testing
- `php -l includes/class-core.php`
- `php -l uninstall.php`
- `php -l secure-fluentform-uploads.php`


------
https://chatgpt.com/codex/tasks/task_e_687686e88070832584d458196910b09d